### PR TITLE
Replace GitHub API calls with curl to fetch OpenSSL version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
             exit 0
           fi
 
-          OPENSSL_TAG=$(wget -q -O- https://api.github.com/repos/openssl/openssl/releases/latest | jq -r '.tag_name')
+          OPENSSL_TAG=$(curl -s -L -o /dev/null -w "%{url_effective}\n" https://github.com/openssl/openssl/releases/latest | sed 's|.*/tag/\(.*\)|\1|')
           echo "[*] upstream openssl tag: $OPENSSL_TAG"
 
           # make sure tag is in format openssl-%d.%d.%d

--- a/Script/build.sh
+++ b/Script/build.sh
@@ -11,7 +11,7 @@ fi
 
 if [ -z "$1" ]; then
     for i in {1..10}; do
-        OPENSSL_TAG=$(wget -q -O- https://api.github.com/repos/openssl/openssl/releases/latest | jq -r '.tag_name')
+        OPENSSL_TAG=$(curl -s -L -o /dev/null -w "%{url_effective}\n" https://github.com/openssl/openssl/releases/latest | sed 's|.*/tag/\(.*\)|\1|')
         if [ -n "$OPENSSL_TAG" ]; then
             break
         fi


### PR DESCRIPTION
This commit addresses the frequent failures encountered when using the GitHub API to retrieve the latest OpenSSL version. By switching to a curl command that directly accesses the releases page, it may improve reliability and reduce the likelihood of hitting API rate limits.

The command `curl -s -L -o /dev/null -w "%{url_effective}\n" https://github.com/openssl/openssl/releases/latest | sed 's|.*/tag/\(.*\)|\1|'` retrieves the latest OpenSSL release version from GitHub by following redirects and extracting the version tag from the final URL.